### PR TITLE
ci: restrict nightly samples jobs to run only in snippets/

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -69,8 +69,9 @@ integration)
     RETURN_CODE=$?
     ;;
 samples)
-    SAMPLES_DIR=samples
-    # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.
+    # run ITs in snippets/ on nightly jobs
+    SAMPLES_DIR=samples/snippets
+    # run ITs in snapshot/ on presubmit PRs
     if [[ ! -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER} ]]
     then
       SAMPLES_DIR=samples/snapshot


### PR DESCRIPTION
To address further RESOURCE_EXHAUSTED errors from nightly samples runs
![image](https://user-images.githubusercontent.com/7338432/97338082-72ab9180-1857-11eb-9bda-dfa1bc28ec11.png)
