### PR TITLE
chore: remove distributionManagement section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,16 +41,7 @@
     <url>https://github.com/googleapis/java-bigquerydatatransfer/issues</url>
     <system>GitHub Issues</system>
   </issueManagement>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <url>https://google.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
+  
   <licenses>
     <license>
       <name>Apache-2.0</name>


### PR DESCRIPTION
All java client libraries inherit the distributionManagement section form shared-config. To prevent individual pom files from overriding the shared-config version of distributionManagement, it is being removed.