### PR TITLE
Revert "chore: pin versions of dependencies for compatibility with Python 3.6 (#1588)"

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,5 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-java:latest
-  digest: sha256:6566dc8226f20993af18e5a4e7a2b1ba85a292b02dedb6a1634cf10e1b418fa5
-
+  digest: sha256:f14e3fefe8e361e85752bd9890c8e56f2fe25f1e89cbb9597e4e3c7a429203a3

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":maintainLockFilesDisabled",
     ":autodetectPinVersions"
   ],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
Reverts googleapis/java-bigquerydatatransfer#1495